### PR TITLE
 商品詳細でカテゴリを3要素表示させる

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -82,8 +82,10 @@ class ItemsController < ApplicationController
   def show
     @item = Item.includes(:images)
     @item = Item.find(params[:id])
-    @category = Item.where(category_id: [1...200]).includes(:images).order('created_at DESC').limit(5)
-    
+    @category_id = @item.category_id
+    @category_parent = Category.find(@category_id).parent.parent
+    @category_child = Category.find(@category_id).parent
+    @category_grandchild = Category.find(@category_id)
   end
 
   def top

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -36,8 +36,10 @@
                     = link_to @item.user.nickname, "/users/#{@item.user_id}"
                 %tr
                   %th カテゴリー
-                  %td 
-                    =@item.category.name
+                  %td
+                    = link_to "#{@category_parent.name}","#"
+                    %br= link_to "#{@category_child.name}","#"
+                    = link_to "#{@category_grandchild.name}","#"
                 %tr
                   %th ブランド
                   %td


### PR DESCRIPTION
＃WHAT
商品詳細ページにおいて、出品商品のカテゴリを親、子、孫を一度に表示させる。
＃WHY
孫要素のみしか表示できなかった箇所を訂正する為