### PR TITLE
画像追加、編集修正

### DIFF
--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -14,6 +14,8 @@ $(document).on('turbolinks:load', function() {
                   </div>`
       return html;
     }
+
+    
     // 投稿編集時
     if (window.location.href.match(/\/items\/\d+\/edit/)){
       //登録済み画像のプレビュー表示欄の要素を取得する

--- a/app/assets/javascripts/item.js
+++ b/app/assets/javascripts/item.js
@@ -14,8 +14,6 @@ $(document).on('turbolinks:load', function() {
                   </div>`
       return html;
     }
-
-    
     // 投稿編集時
     if (window.location.href.match(/\/items\/\d+\/edit/)){
       //登録済み画像のプレビュー表示欄の要素を取得する

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,10 +64,10 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to item_path
+      redirect_to item_path, notice: "商品情報を編集しました"
     else
       @category_parent_array = Category.where(ancestry: nil)
-      render :edit
+      redirect_to edit_item_path, notice: "編集できません。入力必須項目を確認してください"
     end
   end
 
@@ -83,7 +83,7 @@ class ItemsController < ApplicationController
     @item = Item.includes(:images)
     @item = Item.find(params[:id])
     @category_id = @item.category_id
-    # @category_parent = Category.find(@category_id).parent
+    # @category_parent = Category.find(@category_id).parent.parent
     # @category_child = Category.find(@category_id).parent
     # @category_grandchild = Category.find(@category_id)
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-    if @item.save
+    if @item.save!
       redirect_to root_path, notice: "出品しました"
     else
       @item.images.new
@@ -42,8 +42,6 @@ class ItemsController < ApplicationController
 
 
   def edit
-    # @item = Item.new
-    # @item.images.new
     @category_parent_array = Category.where(ancestry: nil)
 
     def get_parent
@@ -68,6 +66,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to item_path
     else
+      @category_parent_array = Category.where(ancestry: nil)
       render :edit
     end
   end
@@ -84,9 +83,9 @@ class ItemsController < ApplicationController
     @item = Item.includes(:images)
     @item = Item.find(params[:id])
     @category_id = @item.category_id
-    @category_parent = Category.find(@category_id).parent.parent
-    @category_child = Category.find(@category_id).parent
-    @category_grandchild = Category.find(@category_id)
+    # @category_parent = Category.find(@category_id).parent
+    # @category_child = Category.find(@category_id).parent
+    # @category_grandchild = Category.find(@category_id)
   end
 
   def top

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -4,6 +4,7 @@
       
   .n__form__container
     =form_for @item do |f|
+      = f.object.errors.messages
       %ul
         .n__image__container
           %p.message 商品出品画像（必須）
@@ -19,15 +20,17 @@
                       .delete-btn
                         %span 削除
             .label-content
-              %label{for: "item_images_attributes_0_src", class: "label-box", id: "label-box--0"}
+              -# = @item.images.length
+              %label{for: "item_images_attributes_#{@item.images.length}_src", class: "label-box", id: "label-box--#{@item.images.length}"}
                 %pre.label-box__text-visible クリックしてファイルをアップロード
             .hidden-content
               = f.fields_for :images do |i|
                 = i.file_field :src, class: "hidden-field"
-                %input{class:"hidden-field", type: "file", name: "item[images_attributes][1][src]", id: "item_images_attributes_1_src" }
-                %input{class:"hidden-field", type: "file", name: "item[images_attributes][2][src]", id: "item_images_attributes_2_src" }
-                %input{class:"hidden-field", type: "file", name: "item[images_attributes][3][src]", id: "item_images_attributes_3_src" }
-                %input{class:"hidden-field", type: "file", name: "item[images_attributes][4][src]", id: "item_images_attributes_4_src" }
+                = i.check_box :_destroy
+                %input{class:"hidden-field", type: "file", name: "item[images_attributes][#{@item.images.length}][src]", id: "item_images_attributes_#{@item.images.length}_src" }
+                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][2][src]", id: "item_images_attributes_2_src" }
+                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][3][src]", id: "item_images_attributes_3_src" }
+                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][4][src]", id: "item_images_attributes_4_src" }
         .n__item__container
           %p.message 商品名（必須）
           = f.text_field :name, class: "name-box",  placeholder: "商品名（必須 40文字まで)"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -4,7 +4,7 @@
       
   .n__form__container
     =form_for @item do |f|
-      = f.object.errors.messages
+      -# = f.object.errors.messages
       %ul
         .n__image__container
           %p.message 商品出品画像（必須）
@@ -20,17 +20,14 @@
                       .delete-btn
                         %span 削除
             .label-content
-              -# = @item.images.length
               %label{for: "item_images_attributes_#{@item.images.length}_src", class: "label-box", id: "label-box--#{@item.images.length}"}
                 %pre.label-box__text-visible クリックしてファイルをアップロード
             .hidden-content
               = f.fields_for :images do |i|
                 = i.file_field :src, class: "hidden-field"
-                = i.check_box :_destroy
-                %input{class:"hidden-field", type: "file", name: "item[images_attributes][#{@item.images.length}][src]", id: "item_images_attributes_#{@item.images.length}_src" }
-                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][2][src]", id: "item_images_attributes_2_src" }
-                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][3][src]", id: "item_images_attributes_3_src" }
-                -# %input{class:"hidden-field", type: "file", name: "item[images_attributes][4][src]", id: "item_images_attributes_4_src" }
+                = i.check_box :_destroy, class: "hidden-checkbox"
+              - @item.images.length.upto(4) do |i|
+                %input{name: "item[images_attributes][#{i}][src]", id: "item_images_attributes_#{i}_src", class: "hidden-field", type: "file"}
         .n__item__container
           %p.message 商品名（必須）
           = f.text_field :name, class: "name-box",  placeholder: "商品名（必須 40文字まで)"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -38,7 +38,8 @@
                   %th カテゴリー
                   %td
                     -# = link_to "#{@category_parent.name}","#"
-                    -# %br= link_to "#{@category_child.name}","#"
+                    -# %br
+                    -# = link_to "#{@category_child.name}","#"
                     -# = link_to "#{@category_grandchild.name}","#"
                 %tr
                   %th ブランド

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -37,9 +37,9 @@
                 %tr
                   %th カテゴリー
                   %td
-                    = link_to "#{@category_parent.name}","#"
-                    %br= link_to "#{@category_child.name}","#"
-                    = link_to "#{@category_grandchild.name}","#"
+                    -# = link_to "#{@category_parent.name}","#"
+                    -# %br= link_to "#{@category_child.name}","#"
+                    -# = link_to "#{@category_grandchild.name}","#"
                 %tr
                   %th ブランド
                   %td

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,5 +11,4 @@
       = content_tag :div, msg, :id => "flash_#{name}" if msg.is_a?(String)
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
   %body
-   
     = yield


### PR DESCRIPTION
#What
商品編集画面にて適切なバリデーションをかける。
バリデーションに引っかかった場合、エラーメッセージを表示する。
画像の追加、削除が適切にできる。

#Why
必須項目を全て入力する仕組みを作り、それに起因するエラーを無くすため。
エラーを防ぐことによって、結果お客様に対して快適なサービスレベルを維持するため。